### PR TITLE
Refactored imports to be in one place together

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 figures/
 full/
+build/*
+*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+figures/
+full/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Save ```Bowerbird.py``` to your project's code folder.
 Bowerbird's Python dependencies (apart from the [Python Standard Library](https://docs.python.org/3/library/ "https://docs.python.org/3/library/")) are ```matplotlib```, ```numpy```, ```pandas``` and ```scipy```. Because Bowerbird tries to make figures look nice, you must also have [LaTeX](https://www.latex-project.org/get/ "https://www.latex-project.org/get/") installed.
 
 # Quick start
-Bowerbird's power is unleashed with a few successive function calls. Here's an example with mock data set `dataSetPopulations.csv` (see repo files). Do these observations of some bowerbird species contain evidence for distinct subpopulations (clusters)?
+Bowerbird's power is unleashed with a few successive function calls. Here's an example with mock data set `dataSetPopulations.csv` (see repo files, and script `example.py`). Do these observations of some bowerbird species contain evidence for distinct subpopulations (clusters)?
 
 To prepare the full data set:
 ```python

--- a/example.py
+++ b/example.py
@@ -1,0 +1,23 @@
+import Bowerbird
+
+if __name__ == "__main__":
+    directoryData               = "./"                # path that contains the data set
+    fileName                    = "BowerbirdMockData.csv"  # name of the CSV file
+    indexColumnStart            = 1                        # index of the first column to be read out (0-based: so 1 refers to the second column)
+    dataSetName                 = "full"                   # name given to the data set within Bowerbird; should be used in other function calls
+    normalise                   = [True] * 6 + [False] * 3 # normalise the first 6 columns, but not the last 3
+    Bowerbird.AHCPrepareDataSetFull(directoryData, fileName, indexColumnStart = indexColumnStart, dataSetName = dataSetName, normalise = normalise)
+
+    linkageType                 = "complete"                     # all options: "complete", "average", "single"
+    dimensionalWeights          = [.5] * 2 + [.5] * 2 + [.2] * 5 # use 3 groups of dimensions (body, courtship and vocals), and give each group equal importance by dividing weight 1 over the group's dimensions
+    numberOfClustersStartSaving = 15                             # save clustering output from this cluster number up to and including 2 (the 1-cluster result is trivial)
+    Bowerbird.AHCCompute(directoryData, linkageType, dimensionalWeights, numberOfClustersStartSaving, dataSetName = dataSetName)
+
+    # Fun fact: some bowerbirds are masters of mimicry, emulating the sounds of pigs, humans and... waterfalls.
+    directoryFigures            = "./figures/" # path used to store figures (doesn't need to exist yet)
+    numberOfClustersHighest     = 15           # highest cluster number to show in progression figures
+    numberOfClustersLowest      = 2            # lowest  cluster number to show in progression figures
+    dimensionsUsed              = ["body length (cm)", "body mass (g)", "court area (sq. m)", "number of partners\nthis year (1)", "mean\nsong duration (s)", "mean\nsong loudness (dB)", "mimics pigs", "mimics humans", "mimics waterfalls"] # names of dimensions
+    listGroupNames              = [r"\textbf{body}", r"\textbf{courtship}", r"\textbf{vocals}"] # names of groups
+    listGroupIndices            = [0, 2, 4]    # indices of each group's first dimension
+    Bowerbird.AHCResultsVisualisation(directoryData, directoryFigures, linkageType, numberOfClustersHighest, numberOfClustersLowest, dimensionsUsed, listGroupNames, listGroupIndices, dataSetName = dataSetName)


### PR DESCRIPTION
Hello,
first of all congratulations for the project. It's quite interesting!

I noticed that imports were scattered in the library, so I moved them altogether at the top (common Python practice, see https://peps.python.org/pep-0008/#imports) and applied common abbrevations for namespaces (np for numpy, pd for pandas, etc..).

I have added also an example script so people can execute that directly for the quickstart.

Best regards